### PR TITLE
Introduce --task-depth option

### DIFF
--- a/src/main/groovy/com/dorongold/gradle/tasktree/TaskTreeTaskNew.groovy
+++ b/src/main/groovy/com/dorongold/gradle/tasktree/TaskTreeTaskNew.groovy
@@ -7,4 +7,9 @@ class TaskTreeTaskNew extends TaskTreeTask {
     void setNoRepeat(boolean noRepeat) {
         super.noRepeat = noRepeat
     }
+
+    @Option(option = "task-depth", description = "descend at most `n' levels into each task dependency")
+    void setMaxDepth(String depth) {
+        super.maxDepth = depth.toInteger()
+    }
 }

--- a/src/main/groovy/com/dorongold/gradle/tasktree/TaskTreeTaskOld.groovy
+++ b/src/main/groovy/com/dorongold/gradle/tasktree/TaskTreeTaskOld.groovy
@@ -7,4 +7,9 @@ class TaskTreeTaskOld extends TaskTreeTask{
     void setNoRepeat(boolean noRepeat) {
         super.noRepeat = noRepeat
     }
+
+    @Option(option = "task-depth", description = "descend at most `n' levels into each task dependency")
+    void setMaxDepth(String depth) {
+        super.maxDepth = depth.toInteger()
+    }
 }


### PR DESCRIPTION
Descends at most `n` levels into the task dependencies. Any remaining children
will be truncated to a single `...` report child, to indicate that the subtree
has been omitted.

Resolves #17 
A side effect also resolves #27 as well.