### PR TITLE
Make it clear which tasks come from included builds

### DIFF
--- a/src/main/groovy/com/dorongold/gradle/tasktree/TaskTreeTask.groovy
+++ b/src/main/groovy/com/dorongold/gradle/tasktree/TaskTreeTask.groovy
@@ -112,6 +112,13 @@ abstract class TaskTreeTask extends AbstractReportTask {
             styledTextOutput.withStyle(isFirst ? Style.Identifier : Style.Normal)
             styledTextOutput.text(entryTask.task.path)
 
+            def currentGradleBuild = project.gradle
+            def refTask = entryTask.task
+            if (refTask.project.gradle != currentGradleBuild) {
+                styledTextOutput.withStyle(Style.Description)
+                styledTextOutput.text(" (included build '" + refTask.project.gradle.rootProject.name + "')")
+            }
+
             if (skippingChildren) {
                 styledTextOutput.text(" ..>")
             }


### PR DESCRIPTION
Currently included build tasks are shown just as paths and it can be confusing (because the parent build may not have such a path or may have an identical path that does something different).