### PR TITLE
Upgrade Apache dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ task createClasspathManifest {
 dependencies {
     compile localGroovy()
     compile gradleApi()
-    compile 'org.apache.commons:commons-lang3:3.4'
+    compile 'org.apache.commons:commons-lang3:3.5'
 
     testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
This upgrade is necessary to fix a vulnerability in [Apache Ant](https://github.com/gradle/gradle/security/advisories/GHSA-j45w-qrgf-25vm).