### PR TITLE
Resilience for failure to detemine task details

### DIFF
--- a/src/test/groovy/com/dorongold/gradle/tasktree/TaskTreeTaskTest.groovy
+++ b/src/test/groovy/com/dorongold/gradle/tasktree/TaskTreeTaskTest.groovy
@@ -201,6 +201,23 @@ class TaskTreeTaskTest extends Specification {
         result.output.contains expectedOutputProjectPersonService()
     }
 
+    @UsesSample('failures/')
+    def "taskTree with failures determining task inputs"() {
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(sampleProject.dir)
+                .withArguments('compileGroovy', 'taskTree', '--with-inputs')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.output =~ expectedOutputProjectFailures()
+
+        result.task(":taskTree").outcome == SUCCESS
+        result.task(":compileGroovy").outcome == SKIPPED
+
+    }
+
 
     static String expectedOutputAllArgumentsWithoutRepeat(Path projectRoot) {
         """
@@ -603,6 +620,21 @@ Project ':services:personService'
 
 (*) - subtree omitted (printed previously)
 '''.stripIndent()
+    }
+
+    static String expectedOutputProjectFailures() {
+        $/
+------------------------------------------------------------
+Root project 'failures'
+------------------------------------------------------------
+
+:compileGroovy
+     <-  \[Error determining inputs: org.gradle.api.GradleException: Cannot infer Groovy class path because no Groovy Jar was found on class path: \[.*failures/build/classes/java/main\]\]
+\\--- :compileJava
+
+
+\(\*\) - subtree omitted \(printed previously\)
+/$.stripIndent()
     }
 
     private void populateBuildFile() {

--- a/src/test/resources/samples/failures/build.gradle
+++ b/src/test/resources/samples/failures/build.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java'
+    id 'groovy' // applying the groovy plugin without setting groovy runtime causes groovyCompile to fail resolving inputs: https://docs.gradle.org/current/userguide/groovy_plugin.html#sec:automatic_configuration_of_groovyclasspath
+    id 'com.dorongold.task-tree'
+}
+

--- a/src/test/resources/samples/failures/settings.gradle
+++ b/src/test/resources/samples/failures/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "failures"

--- a/src/test/resources/samples/failures/src/main/groovy/org/gradle/sample/Main.groovy
+++ b/src/test/resources/samples/failures/src/main/groovy/org/gradle/sample/Main.groovy
@@ -1,0 +1,7 @@
+package samples.failures.src.main.groovy.org.gradle.sample
+
+class Main {
+    static void main(String[] args) {
+        System.out.println("Hello, world!")
+    }
+}


### PR DESCRIPTION
In case of failure in resolving one of the following:
- task inputs
- task outputs
- task description

Continue building the task tree. Display the failure reason
instead of the resolved detail in the tree.

closes #57 
